### PR TITLE
Wiki Link Substitution and non-alphanumeric characters in display text.

### DIFF
--- a/extensions/PonyDocs/PonyDocsExtension.body.php
+++ b/extensions/PonyDocs/PonyDocsExtension.body.php
@@ -1516,8 +1516,7 @@ HEREDOC;
 		 *  [[:Topic]]									Link to topic in global namespace - preceding colon required!
 		 */
 
-		//if( $doWikiLinkSubstitution && preg_match_all( "/\[\[([A-Za-z0-9,:._ -]*)([|]?([A-Za-z0-9,:.'_!@\"()#$ -]*))\]\]/", $text, $matches, PREG_SET_ORDER ))
-		if( $doWikiLinkSubstitution && preg_match_all( "/\[\[([A-Za-z0-9,:._ -]*)(\#[A-Za-z0-9 ._-]+)?([|]?(.*))\]\]/", $text, $matches, PREG_SET_ORDER ))
+		if( $doWikiLinkSubstitution && preg_match_all( "/\[\[([A-Za-z0-9,:._ -]*)(\#[A-Za-z0-9 ._-]+)?([|]?(.+?))\]\]?/", $text, $matches, PREG_SET_ORDER ))
 		{
 			//echo '<pre>'; print_r( $matches ); die();
 			/**

--- a/extensions/PonyDocs/PonyDocsExtension.body.php
+++ b/extensions/PonyDocs/PonyDocsExtension.body.php
@@ -1517,7 +1517,7 @@ HEREDOC;
 		 */
 
 		//if( $doWikiLinkSubstitution && preg_match_all( "/\[\[([A-Za-z0-9,:._ -]*)([|]?([A-Za-z0-9,:.'_!@\"()#$ -]*))\]\]/", $text, $matches, PREG_SET_ORDER ))
-		if( $doWikiLinkSubstitution && preg_match_all( "/\[\[([A-Za-z0-9,:._ -]*)(\#[A-Za-z0-9 ._-]+)?([|]?([A-Za-z0-9,:.'_?!@\/\"()#$ -{}]*))\]\]/", $text, $matches, PREG_SET_ORDER ))
+		if( $doWikiLinkSubstitution && preg_match_all( "/\[\[([A-Za-z0-9,:._ -]*)(\#[A-Za-z0-9 ._-]+)?([|]?(.*))\]\]/", $text, $matches, PREG_SET_ORDER ))
 		{
 			//echo '<pre>'; print_r( $matches ); die();
 			/**


### PR DESCRIPTION
We are using ponydocs for localization(Ex. http://docs.genesys.com/i18n/DEU/Documentation/IW/8.5.1/Help/Welcome) and noticed that ponydocs  wikilinks with non-alphanumeric characters were breaking. Implemented this fix to support non-alphanumeric characters in the display text.

Change based on MediaWiki's regex in parser.php file:

```php
if ( !$tc ) {
			$tc = Title::legalChars() . '#%';
			# Match a link having the form [[namespace:link|alternate]]trail
			$e1 = "/^([{$tc}]+)(?:\\|(.+?))?]](.*)\$/sD";
			# Match cases where there is no "]]", which might still be images
			$e1_img = "/^([{$tc}]+)\\|(.*)\$/sD";
		}
```