### PR TITLE
302 redirect (instead of 301) for SpecialLatestDoc

### DIFF
--- a/extensions/PonyDocs/PonyDocsExtension.body.php
+++ b/extensions/PonyDocs/PonyDocsExtension.body.php
@@ -537,8 +537,11 @@ class PonyDocsExtension
 				}
 			}
 			if(!$found) {
-				if (PONYDOCS_DEBUG) {error_log("DEBUG [" . __METHOD__ . ":" . __LINE__ . "] redirecting to $wgScriptPath/Special:PonyDocsLatestDoc?t=$title");}
-				header("Location: " . $wgScriptPath . "/Special:SpecialLatestDoc?t=$title", true, 301);
+				if (PONYDOCS_DEBUG) {
+					error_log("DEBUG [" . __METHOD__ . ":" . __LINE__
+						. "] redirecting to $wgScriptPath/Special:PonyDocsLatestDoc?t=$title");
+				}
+				header("Location: " . $wgScriptPath . "/Special:SpecialLatestDoc?t=$title", true, 302);
 				exit(0);
 			}
 


### PR DESCRIPTION
Since redirection to special latest doc is dynamic, based on the existence or not of a specific topic in latest, we should not 301 redirect to it.