### PR TITLE
Fixed a call-time pass-by-reference which produced a PHP fatal error

### DIFF
--- a/extensions/PonyDocs/PonyDocsZipExport.php
+++ b/extensions/PonyDocs/PonyDocsZipExport.php
@@ -130,8 +130,8 @@ class PonyDocsZipExport extends PonyDocsBaseExport {
 		$coverPageDoc = new DOMDocument();
 		@$coverPageDoc->loadHTML($coverPageHTML);
 
-		self::prepareImageRequests($manualDoc, $rollingCurl, $tempDirPath,  &$imgData);
-		self::prepareImageRequests($coverPageDoc, $rollingCurl, $tempDirPath, &$imgData);
+		self::prepareImageRequests($manualDoc, $rollingCurl, $tempDirPath,  $imgData);
+		self::prepareImageRequests($coverPageDoc, $rollingCurl, $tempDirPath, $imgData);
 
 		// Execute the RollingCurl requests
 		$rollingCurl->execute();


### PR DESCRIPTION
On PHP 5.5 and onwards, passing variables with a reference don't accept the ampersand on the method caller anymore. PHP produces a fatal error. Removed the ampersand at two method calls
