### PR TITLE
merge all consecutive spaces into one for inline TOC link generation

### DIFF
--- a/extensions/PonyDocs/PonyDocsTOC.php
+++ b/extensions/PonyDocs/PonyDocsTOC.php
@@ -487,6 +487,9 @@ class PonyDocsTOC
 	 * @return string
 	 */
 	static public function normalizeSection( $secText ) {
+		// Replace 2 or more spaces with 1 space
+		$secText = preg_replace( '/\s{2,}/', ' ', $secText );
+		// Trim whitespace from beginning and end of string, and then replace spaces with underscores
 		$secText = str_replace( ' ', '_', preg_replace( '/^\s*|\s*$/', '', $secText ) );
 		return $secText;
 	}


### PR DESCRIPTION
Fixes a bug in inline TOC jump links for headings with consecutive spaces